### PR TITLE
Update cacerts to 2021-09-30.

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=cacerts
 pkg_origin=core
-version=2020-12-08
+version=2021-09-30
 pkg_description="\
 The Mozilla CA certificate store in PEM format (around 250KB uncompressed).
 "


### PR DESCRIPTION
Updating cacerts which has no no DST Root CA X3 entry
to resolve ERROR: cannot verify "xxx" certificate, issued by 'CN=R3,O=Let\'s Encrypt,C=US':
  Issued certificate has expired.